### PR TITLE
Add logic to edit a palette name from the DOM

### DIFF
--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -17,7 +17,8 @@ import {
   deletePalette,
   deleteProject,
   getAllPalettes,
-  editProjectName
+  editProjectName,
+  editPaletteName
 } from "../../utilities/apiCalls";
 
 export class App extends Component {
@@ -205,7 +206,14 @@ export class App extends Component {
     const newProject = await editProjectName(project);
     const updated_projects = user_projects.map(project => project.id === newProject.id ? newProject : project);
     this.setState({ user_projects: updated_projects });
-  }
+  };
+
+  updatePaletteName = async palette => {
+    const { user_palettes } = this.state;
+    const newPalette = await editPaletteName(palette);
+    const updated_palettes = user_palettes.map(palette => palette.id === newPalette.id ? newPalette: palette);
+    this.setState({ user_palettes: updated_palettes });
+  };
 
   render() {
     const {
@@ -274,6 +282,7 @@ export class App extends Component {
                 />
                 <ProjectsContainer
                   updateProjectName={this.updateProjectName}
+                  updatePaletteName={this.updatePaletteName}
                   projects={user_projects}
                   palettes={user_palettes}
                   trashPalette={this.trashPalette}

--- a/src/Components/PaletteCard/PaletteCard.js
+++ b/src/Components/PaletteCard/PaletteCard.js
@@ -1,9 +1,41 @@
-import React from 'react';
+import React, { Component } from 'react';
 import './PaletteCard.css';
 import { Link } from 'react-router-dom';
 
 
-export const PaletteCard = ({ palette, trashPalette, grabPalette, showPalette}) => {
+export class PaletteCard extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      nameInput: props.palette.name,
+      disabled: true,
+      error: ''
+    }
+  }
+
+  editName = () => {
+    this.setState({ disabled: false });
+  };
+
+  saveName = async () => {
+    const { palette, updatePaletteName } = this.props;
+    const { nameInput } = this.state;
+    const newPalette = {
+      ...palette,
+      name: nameInput
+    };
+    updatePaletteName(newPalette);
+    this.setState({ disabled: true});
+  };
+
+  handleChange = (e) => {
+    this.setState({ nameInput: e.target.value})
+  };
+
+
+  render() {
+  const { palette, trashPalette, grabPalette, showPalette } = this.props;
+  const { nameInput, disabled, error } = this.state;
   const colors = Object.values(palette).slice(2)
   const swatch = colors.map((hex, index) => {
     const divStyle = {
@@ -13,10 +45,12 @@ export const PaletteCard = ({ palette, trashPalette, grabPalette, showPalette}) 
     }
     return <div style={divStyle} key={index}></div>
   })
-
-  return (
+      return (
     <div>
-      <h4>{palette.name}</h4>
+      { error && <p>{error}</p> }
+        <input type='text' onChange={this.handleChange} disabled={disabled} value={nameInput}></input>
+      { disabled && <p onClick={this.editName}>Edit</p> } 
+      { !disabled && <p onClick={this.saveName}>Save</p> }
       <div>{swatch}</div>
       {grabPalette && (
         <Link to="/">
@@ -31,6 +65,7 @@ export const PaletteCard = ({ palette, trashPalette, grabPalette, showPalette}) 
       )}
     </div>
   );
+  }
 }
 
 export default PaletteCard;

--- a/src/Components/PaletteContainer/PaletteContainer.js
+++ b/src/Components/PaletteContainer/PaletteContainer.js
@@ -2,9 +2,9 @@ import React from "react";
 import "./PaletteContainer.css";
 import PaletteCard from "../PaletteCard/PaletteCard";
 
-export const PaletteContainer = ({ palettes, grabPalette }) => {
+export const PaletteContainer = ({ palettes, grabPalette, updatePaletteName }) => {
   const paletteCards = palettes.map(palette => {
-    return <PaletteCard palette={palette} grabPalette={grabPalette} key={palette.id} />;
+    return <PaletteCard palette={palette} grabPalette={grabPalette} updatePaletteName={updatePaletteName} key={palette.id} />;
   });
 
   return <section>{paletteCards}</section>;

--- a/src/Components/ProjectCard/ProjectCard.js
+++ b/src/Components/ProjectCard/ProjectCard.js
@@ -34,10 +34,10 @@ export class ProjectCard extends Component {
 
 
   render() {
-    const { project, palettes, trashPalette, trashProject, showPalette } = this.props;
+    const { project, palettes, trashPalette, trashProject, showPalette, updatePaletteName} = this.props;
     const { disabled, nameInput, error } = this.state;
     const paletteCards = palettes.map((palette, index) => {
-      return <PaletteCard key={index} palette={palette} trashPalette={trashPalette} showPalette={showPalette} />
+      return <PaletteCard key={index} palette={palette} trashPalette={trashPalette} showPalette={showPalette} updatePaletteName={updatePaletteName} />
     });
 
     return (

--- a/src/Components/ProjectsContainer/ProjectsContainer.js
+++ b/src/Components/ProjectsContainer/ProjectsContainer.js
@@ -2,10 +2,10 @@ import React from 'react';
 import ProjectCard from '../ProjectCard/ProjectCard'
 import './ProjectsContainer.css';
 
-export const ProjectsContainer = ({ projects, palettes, trashPalette, trashProject, showPalette, updateProjectName }) => {
+export const ProjectsContainer = ({ projects, palettes, trashPalette, trashProject, showPalette, updateProjectName, updatePaletteName }) => {
   const projectCards = projects.map((project, index) => {
     const projectPalettes = palettes.filter( palette => project.id === palette.project_id)
-    return <ProjectCard project={project} palettes={projectPalettes} trashPalette={trashPalette} trashProject={trashProject} showPalette={showPalette} updateProjectName={updateProjectName} key={index} />
+    return <ProjectCard project={project} palettes={projectPalettes} trashPalette={trashPalette} trashProject={trashProject} showPalette={showPalette} updateProjectName={updateProjectName} updatePaletteName={updatePaletteName} key={index} />
   })
 
   return (

--- a/src/utilities/apiCalls.js
+++ b/src/utilities/apiCalls.js
@@ -165,3 +165,23 @@ export const editProjectName = async (project) => {
     throw new Error (error.message)
   }
 };
+
+export const editPaletteName = async (palette) => {
+  try { 
+    const options = {
+      method: 'PATCH',
+      body: JSON.stringify(palette),
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+    const response = await fetch(`http://localhost:3001/palettes/${palette.id}`, options);
+    if (!response.ok) {
+      throw new Error('Unable to edit Palette');
+    } 
+    const result = await response.json();
+    return cleanPalettes([result])[0];
+  } catch (error) {
+    throw new Error (error.message)
+  }
+};


### PR DESCRIPTION
Co-Authored-By: Chris Lane <c.lane.dev@gmail.com>

## Problem
As a user, needed the ability to update a palette name. 

## Solution
Added functionality that allowed the user to patch the name of any palette they created.